### PR TITLE
Swiping Fixes

### DIFF
--- a/app/components/profile-custom.js
+++ b/app/components/profile-custom.js
@@ -8,7 +8,9 @@ export default Component.extend(Swiping, {
 
   didInsertElement: function() {
     this._super(...arguments);
-    this.updateDater();
+    if (this.get('dating.dating_alts')) {
+      this.updateDater();
+    }
   },
 
   match: computed('dating.match', function() {

--- a/app/components/profile-custom.js
+++ b/app/components/profile-custom.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { observer } from '@ember/object';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Swiping from 'ares-webportal/mixins/swiping';
 
@@ -10,6 +10,21 @@ export default Component.extend(Swiping, {
     this._super(...arguments);
     this.updateDater();
   },
+
+  match: computed('dating.match', function() {
+    return this.get('dating.match') || 'None';
+  }),
+
+  swipe: computed('dating.swipe', function() {
+    let swipe = this.get('dating.swipe');
+    if (!swipe) {
+      return 'None';
+    } else if (swipe.missed) {
+      return swipe.type + ' (Missed Connection)';
+    } else {
+      return swipe.type;
+    }
+  }),
 
   updateDatingInfo: function(match, swipe) {
     this.set('dating.match', match);

--- a/app/components/profile-custom.js
+++ b/app/components/profile-custom.js
@@ -38,7 +38,7 @@ export default Component.extend(Swiping, {
       this.gameApi.requestOne('matchFor', { id: this.char.id, dater: dater.name })
       .then( (response) => {
         if (response.error) {
-          return
+          return;
         }
         this.updateDatingInfo(response.match, response.swipe);
       });

--- a/app/components/profile-custom.js
+++ b/app/components/profile-custom.js
@@ -34,6 +34,7 @@ export default Component.extend(Swiping, {
   actions: {
     daterChanged: function(dater) {
       this.set('dating.swiping_with', dater);
+      this.setDater(dater);
       this.gameApi.requestOne('matchFor', { id: this.char.id, dater: dater.name })
       .then( (response) => {
         if (response.error) {

--- a/app/components/profile-custom.js
+++ b/app/components/profile-custom.js
@@ -1,7 +1,31 @@
 import Component from '@ember/component';
-import Swiping from 'ares-webportal/mixins/swiping';
+import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Swiping from 'ares-webportal/mixins/swiping';
 
 export default Component.extend(Swiping, {
   tagName: '',
+
+  didInsertElement: function() {
+    this._super(...arguments);
+    this.updateDater();
+  },
+
+  updateDatingInfo: function(match, swipe) {
+    this.set('dating.match', match);
+    this.set('dating.swipe', swipe);
+  },
+
+  actions: {
+    daterChanged: function(dater) {
+      this.set('dating.swiping_with', dater);
+      this.gameApi.requestOne('matchFor', { id: this.char.id, dater: dater.name })
+      .then( (response) => {
+        if (response.error) {
+          return
+        }
+        this.updateDatingInfo(response.match, response.swipe);
+      });
+    },
+  },
 });

--- a/app/components/profile-demographics.js
+++ b/app/components/profile-demographics.js
@@ -1,11 +1,4 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 
 export default Component.extend({
-
-  showDatingSection: computed('dating', function() {
-    var dating = this.get('dating');
-    return dating.match || dating.swipe;
-  }),
-
 });

--- a/app/components/profile-system.js
+++ b/app/components/profile-system.js
@@ -26,5 +26,8 @@ export default Component.extend({
     reloadChar() {
       this.reloadChar();
     },
+    setDater(dater) {
+      this.setDater(dater);
+    },
   },
 });

--- a/app/controllers/char.js
+++ b/app/controllers/char.js
@@ -2,6 +2,9 @@ import Controller from '@ember/controller';
 import AuthenticatedController from 'ares-webportal/mixins/authenticated-controller';
 
 export default Controller.extend(AuthenticatedController, {
+    queryParams: ['dater'],
+
+    dater: null,
 
     actions: {
         reloadChar: function() {
@@ -12,7 +15,9 @@ export default Controller.extend(AuthenticatedController, {
           if (folder === model_folder) {
             this.get('model.char.files').pushObject( { folder: folder, name: file, path: `/${folder}/${file}` } );
           }
-        }
+        },
+        setDater: function(dater) {
+          this.set('dater', dater.name);
+        },
     }
-    
 });

--- a/app/controllers/dating.js
+++ b/app/controllers/dating.js
@@ -18,7 +18,8 @@ export default Controller.extend(Swiping, AuthenticatedController, {
 
   actions: {
     showOrHideAlts: function(option) {
-      this.gameApi.requestOne('showOrHideAlts', { option: option }, null)
+      let dater = this.get('dating.swiping_with');
+      this.gameApi.requestOne('showOrHideAlts', { option: option, dater: dater.name }, null)
       .then( (response) => {
         if (response.error) {
           return;

--- a/app/controllers/dating.js
+++ b/app/controllers/dating.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
 import Swiping from 'ares-webportal/mixins/swiping';
+import AuthenticatedController from 'ares-webportal/mixins/authenticated-controller';
 
-export default Controller.extend(Swiping, {
+export default Controller.extend(Swiping, AuthenticatedController, {
   queryParams: ['dater'],
 
   dater: null,
@@ -19,13 +20,7 @@ export default Controller.extend(Swiping, {
     },
 
     daterChanged: function(dater) {
-      this.gameApi.requestOne('swipeWith', { char: dater.name })
-      .then( (response) => {
-        if (response.error) {
-          return;
-        }
-        this.set('dater', dater.name);
-      });
+      this.set('dater', dater.name);
     },
   },
 });

--- a/app/controllers/dating.js
+++ b/app/controllers/dating.js
@@ -10,8 +10,10 @@ export default Controller.extend(Swiping, AuthenticatedController, {
   dating: {},
 
   modelObserver: observer('model', function() {
-    this.set('dating.dating_alts', this.get('model.dating_alts'));
-    this.updateDater(this.currentUser.name);
+    if (!this.get('dating.dating_alts')) {
+      this.set('dating.dating_alts', this.get('model.dating_alts'));
+      this.updateDater(this.currentUser.name);
+    }
   }),
 
   actions: {
@@ -29,6 +31,13 @@ export default Controller.extend(Swiping, AuthenticatedController, {
     daterChanged: function(dater) {
       this.set('dating.swiping_with', dater);
       this.set('dater', dater.name);
+      this.gameApi.requestOne('datingApp', { dater: dater.name })
+      .then( (response) => {
+        if (response.error) {
+          return;
+        }
+        this.set('model', response);
+      });
     },
   },
 });

--- a/app/controllers/dating.js
+++ b/app/controllers/dating.js
@@ -2,6 +2,10 @@ import Controller from '@ember/controller';
 import Swiping from 'ares-webportal/mixins/swiping';
 
 export default Controller.extend(Swiping, {
+  queryParams: ['dater'],
+
+  dater: null,
+
   actions: {
     showOrHideAlts: function(option) {
       this.gameApi.requestOne('showOrHideAlts', { option: option }, null)
@@ -20,7 +24,7 @@ export default Controller.extend(Swiping, {
         if (response.error) {
           return;
         }
-        this.send('reloadModel');
+        this.set('dater', dater.name);
       });
     },
   },

--- a/app/controllers/dating.js
+++ b/app/controllers/dating.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { observer } from '@ember/object';
 import Swiping from 'ares-webportal/mixins/swiping';
 import AuthenticatedController from 'ares-webportal/mixins/authenticated-controller';
 
@@ -6,6 +7,12 @@ export default Controller.extend(Swiping, AuthenticatedController, {
   queryParams: ['dater'],
 
   dater: null,
+  dating: {},
+
+  modelObserver: observer('model', function() {
+    this.set('dating.dating_alts', this.get('model.dating_alts'));
+    this.updateDater(this.currentUser.name);
+  }),
 
   actions: {
     showOrHideAlts: function(option) {
@@ -20,6 +27,7 @@ export default Controller.extend(Swiping, AuthenticatedController, {
     },
 
     daterChanged: function(dater) {
+      this.set('dating.swiping_with', dater);
       this.set('dater', dater.name);
     },
   },

--- a/app/mixins/swiping.js
+++ b/app/mixins/swiping.js
@@ -5,9 +5,33 @@ export default Mixin.create({
   gameApi: service(),
   flashMessages: service(),
 
+  updateDater: function() {
+    if (this.dating && !this.get('dating.swiping_with')) {
+      let alts = this.get('dating.dating_alts');
+
+      if (this.get('dater')) {
+        this.setSwipingName(this.get('dater'));
+      }
+
+      if (!this.get('dating.swiping_with') && this.currentUser) {
+        this.setSwipingName(this.currentUser.name);
+      }
+
+      if (!this.get('dating.swiping_with')) {
+        this.set('dating.swiping_with', alts[0]);
+      }
+    }
+  },
+
+  setSwipingName: function(name) {
+    let dater = this.get('dating.dating_alts').find(a => a.name == name);
+    this.set('dating.swiping_with', dater);
+  },
+
   actions: {
     swipe: function(name, type) {
-      this.gameApi.requestOne('swipeFor', { target: name, type: type }, null)
+      let dater = this.get('dating.swiping_with');
+      this.gameApi.requestOne('swipeFor', { target: name, type: type, dater: dater.name }, null)
       .then( (response) => {
         if (response.error) {
           return;

--- a/app/mixins/swiping.js
+++ b/app/mixins/swiping.js
@@ -28,6 +28,10 @@ export default Mixin.create({
     this.set('dating.swiping_with', dater);
   },
 
+  updateDatingInfo: function(match, swipe) {
+    this.send('reloadModel');
+  },
+
   actions: {
     swipe: function(name, type) {
       let dater = this.get('dating.swiping_with');
@@ -37,7 +41,7 @@ export default Mixin.create({
           return;
         }
         this.flashMessages.success(response.message);
-        this.send('reloadModel');
+        this.updateDatingInfo(response.match, response.swipe);
      });
     },
   },

--- a/app/routes/char.js
+++ b/app/routes/char.js
@@ -11,6 +11,12 @@ export default Route.extend(DefaultRoute, ReloadableRoute, AuthenticatedControll
     headData: service(),
     router: service(),
     
+    queryParams: {
+        dater: {
+            replace: true,
+        },
+    },
+
     afterModel: function(model) { 
         if (model.get('char.playerbit')) {
             this.router.transitionTo('player', model.get('char.name'));
@@ -23,9 +29,15 @@ export default Route.extend(DefaultRoute, ReloadableRoute, AuthenticatedControll
         return RSVP.hash({
             char: api.requestOne('character', { id: params['id'] }),
             game: this.modelFor('application').game,
-            dating: api.requestOne('matchFor', { id: params['id'] }),
+            dating: api.requestOne('matchFor', { id: params['id'], dater: params['dater'] }),
             scenes: api.requestOne('scenes', { char_id: params['id'], filter: 'All', page: 1 }),
             sceneOptions: api.requestOne('sceneOptions') })
             .then((model) => EmberObject.create(model));
-    }
+    },
+
+    resetController: function(controller, isExiting, transition) {
+      if (isExiting) {
+        controller.set('dater', null);
+      }
+    },
 });

--- a/app/routes/char.js
+++ b/app/routes/char.js
@@ -4,8 +4,9 @@ import RSVP from 'rsvp';
 import { inject as service } from '@ember/service';
 import ReloadableRoute from 'ares-webportal/mixins/reloadable-route';
 import DefaultRoute from 'ares-webportal/mixins/default-route';
+import AuthenticatedController from 'ares-webportal/mixins/authenticated-controller';
 
-export default Route.extend(DefaultRoute, ReloadableRoute, {
+export default Route.extend(DefaultRoute, ReloadableRoute, AuthenticatedController, {
     gameApi: service(),
     headData: service(),
     router: service(),
@@ -16,7 +17,7 @@ export default Route.extend(DefaultRoute, ReloadableRoute, {
         }
         this.set('headData.robotindex', true);
     },
-    
+
     model: function(params) {
         let api = this.gameApi;
         return RSVP.hash({

--- a/app/routes/dating.js
+++ b/app/routes/dating.js
@@ -7,8 +7,15 @@ import DefaultRoute from 'ares-webportal/mixins/default-route';
 export default Route.extend(DefaultRoute, ReloadableRoute, {
     gameApi: service(),
 
+    queryParams: {
+      dater: {
+        replace: true,
+        refreshModel: true,
+      },
+    },
+
     model: function(params) {
         let api = this.gameApi;
-        return api.requestOne('datingApp');
+        return api.requestOne('datingApp', { dater: params['dater'] });
     },
 });

--- a/app/routes/dating.js
+++ b/app/routes/dating.js
@@ -11,7 +11,6 @@ export default Route.extend(DefaultRoute, ReloadableRoute, AuthenticatedRoute, {
   queryParams: {
     dater: {
       replace: true,
-      refreshModel: true,
     },
   },
 

--- a/app/routes/dating.js
+++ b/app/routes/dating.js
@@ -1,21 +1,22 @@
 import EmberObject from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ReloadableRoute from 'ares-webportal/mixins/reloadable-route';
+import AuthenticatedRoute from 'ares-webportal/mixins/authenticated-route';
 import DefaultRoute from 'ares-webportal/mixins/default-route';
+import ReloadableRoute from 'ares-webportal/mixins/reloadable-route';
 
-export default Route.extend(DefaultRoute, ReloadableRoute, {
-    gameApi: service(),
+export default Route.extend(DefaultRoute, ReloadableRoute, AuthenticatedRoute, {
+  gameApi: service(),
 
-    queryParams: {
-      dater: {
-        replace: true,
-        refreshModel: true,
-      },
+  queryParams: {
+    dater: {
+      replace: true,
+      refreshModel: true,
     },
+  },
 
-    model: function(params) {
-        let api = this.gameApi;
-        return api.requestOne('datingApp', { dater: params['dater'] });
-    },
+  model: function(params) {
+    let api = this.gameApi;
+    return api.requestOne('datingApp', { dater: params['dater'] });
+  },
 });

--- a/app/templates/char.hbs
+++ b/app/templates/char.hbs
@@ -3,7 +3,7 @@
 <h1>{{this.model.char.profile_title}}</h1>
 
 <div class="row profile-wrap">
-    <ProfileDemographics @char={{this.model.char}} @dating={{this.model.dating}} />
+    <ProfileDemographics @char={{this.model.char}} />
 </div>
 
 

--- a/app/templates/char.hbs
+++ b/app/templates/char.hbs
@@ -25,7 +25,7 @@
 
 <div class="profile-tab">
 
-  <ProfileSystem @char={{this.model.char}} @game={{this.model.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} @dating={{this.model.dating}} @currentUser={{this.currentUser}} />
+  <ProfileSystem @char={{this.model.char}} @game={{this.model.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} @dating={{this.model.dating}} @currentUser={{this.currentUser}} @dater={{this.dater}} @setDater={{action "setDater"}}/>
 
 </div>
 

--- a/app/templates/char.hbs
+++ b/app/templates/char.hbs
@@ -25,7 +25,7 @@
 
 <div class="profile-tab">
 
-  <ProfileSystem @char={{this.model.char}} @game={{this.model.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} />
+  <ProfileSystem @char={{this.model.char}} @game={{this.model.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} @dating={{this.model.dating}} @currentUser={{this.currentUser}} />
 
 </div>
 

--- a/app/templates/components/char-group-list.hbs
+++ b/app/templates/components/char-group-list.hbs
@@ -7,7 +7,7 @@
             {{#each this.chars as |c| }}
     
              <div class="icon-gallery-item">
-                <CharIcon @char={{c}} />
+               <CharIcon @char={{c}} @dater={{this.dater}} />
               </div>
           
             {{/each}}

--- a/app/templates/components/char-icon.hbs
+++ b/app/templates/components/char-icon.hbs
@@ -1,7 +1,7 @@
 <div class="char-icon-container">
     
 <div class="log-icon-container">
-    <LinkTo @route="char" @model={{this.char.name}}>
+    <LinkTo @route="char" @model={{this.char.name}} @query={{hash dater=this.dater}}>
        {{#if this.char.icon}}
         <img alt="{{this.char.name}}'s icon" class="log-icon" src="/game/uploads/{{this.char.icon}}" >
        {{else}}

--- a/app/templates/components/profile-custom.hbs
+++ b/app/templates/components/profile-custom.hbs
@@ -3,6 +3,15 @@
     {{{ansi-format text=char.custom.dateprof}}}
     {{#if this.canSwipe}}
     <div class="action-buttons">
+      <div class="dating-char-select">
+        <PowerSelect @selected={{this.dating.swiping_with}}
+                     @options={{this.dating.dating_alts}}
+                     @searchEnabled=true
+                     @searchField="name"
+                     @onChange={{action "daterChanged"}} as |dater|>
+          <CharIconTiny @char={{dater}} />
+        </PowerSelect>
+      </div>
       <button {{action "swipe" char.name "interested"}} class="btn btn-secondary">Interested</button>
       <button {{action "swipe" char.name "curious"}} class="btn btn-secondary">Curious</button>
       <button {{action "swipe" char.name "skip"}} class="btn btn-secondary">Skip</button>

--- a/app/templates/components/profile-custom.hbs
+++ b/app/templates/components/profile-custom.hbs
@@ -2,20 +2,34 @@
 <div id="dateprof-dateprof" class="tab-pane fade">
     {{{ansi-format text=char.custom.dateprof}}}
     {{#if this.canSwipe}}
-    <div class="action-buttons">
-      <div class="dating-char-select">
-        <PowerSelect @selected={{this.dating.swiping_with}}
-                     @options={{this.dating.dating_alts}}
-                     @searchEnabled=true
-                     @searchField="name"
-                     @onChange={{action "daterChanged"}} as |dater|>
-          <CharIconTiny @char={{dater}} />
-        </PowerSelect>
+    <div class="dating-ui">
+      <div>
+        <div class="dating-char-select">
+          <PowerSelect @selected={{this.dating.swiping_with}}
+                       @options={{this.dating.dating_alts}}
+                       @searchEnabled=true
+                       @searchField="name"
+                       @onChange={{action "daterChanged"}} as |dater|>
+            <CharIconTiny @char={{dater}} />
+          </PowerSelect>
+        </div>
+        <dl>
+          <div>
+            <dt>Match</dt>
+            <dd>{{ this.match }}</dd>
+          </div>
+          <div>
+            <dt>Swipe</dt>
+            <dd>{{ this.swipe }}</dd>
+          </div>
+        </dl>
       </div>
-      <button {{action "swipe" char.name "interested"}} class="btn btn-secondary">Interested</button>
-      <button {{action "swipe" char.name "curious"}} class="btn btn-secondary">Curious</button>
-      <button {{action "swipe" char.name "skip"}} class="btn btn-secondary">Skip</button>
-      <button {{action "swipe" char.name "missed_connection"}} class="btn btn-secondary">Missed Connection</button>
+      <div>
+        <button {{action "swipe" char.name "interested"}} class="btn btn-secondary">Interested</button>
+        <button {{action "swipe" char.name "curious"}} class="btn btn-secondary">Curious</button>
+        <button {{action "swipe" char.name "skip"}} class="btn btn-secondary">Skip</button>
+        <button {{action "swipe" char.name "missed_connection"}} class="btn btn-secondary">Missed Connection</button>
+      </div>
     </div>
     {{/if}}
 </div>

--- a/app/templates/components/profile-demographics.hbs
+++ b/app/templates/components/profile-demographics.hbs
@@ -11,7 +11,7 @@
 
     <div class="col col-12 col-lg-8 profile-demo-wrap">        
 
-        <div class="profile-box">
+      <div class="profile-box">
 
         {{#each this.char.demographics as |demo|}}
         <div class="row">
@@ -42,7 +42,6 @@
 
 
         {{#if this.char.handle}}
-        
         <div class="row">
             <div class="col-sm-4">
                     <b>Player</b> 
@@ -51,7 +50,6 @@
                     <a href="http://arescentral.aresmush.com/handle/{{this.char.handle}}">{{this.char.handle}}</a>
             </div>
         </div>
-        
         {{/if}}
         
         <div class="row">
@@ -63,34 +61,6 @@
             </div>
         </div>
 
-        {{#if showDatingSection}}
-        <div class="profile-divider">
-        </div>
-        {{/if}}
-
-        {{#if this.dating.match}}
-        <div class="row">
-          <div class="col-sm-4">
-            <b>Dating Match</b>
-          </div>
-          <div class="col-sm-8">
-            {{this.dating.match}}
-          </div>
-        </div>
-        {{/if}}
-
-        {{#if this.dating.swipe}}
-        <div class="row">
-          <div class="col-sm-4">
-            <b>Dating Swipe</b>
-          </div>
-          <div class="col-sm-8">
-            {{this.dating.swipe.type}}{{if this.dating.swipe.missed " (Missed Connection)"}}
-          </div>
-        </div>
-        {{/if}}
-
-        </div>
-        
+      </div>
     </div>
 </div>

--- a/app/templates/components/profile-system.hbs
+++ b/app/templates/components/profile-system.hbs
@@ -129,6 +129,6 @@
   </div>
   {{/if}}
   
-  <ProfileCustom @char={{this.char}} @game={{this.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} />
+  <ProfileCustom @char={{this.char}} @game={{this.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} @dating={{this.dating}} @currentUser={{this.currentUser}} />
   
 </div>

--- a/app/templates/components/profile-system.hbs
+++ b/app/templates/components/profile-system.hbs
@@ -129,6 +129,6 @@
   </div>
   {{/if}}
   
-  <ProfileCustom @char={{this.char}} @game={{this.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} @dating={{this.dating}} @currentUser={{this.currentUser}} />
+  <ProfileCustom @char={{this.char}} @game={{this.game}} @reloadChar={{action "reloadChar"}} @canSwipe={{this.canSwipe}} @dating={{this.dating}} @currentUser={{this.currentUser}} @dater={{this.dater}} @setDater={{action "setDater"}} />
   
 </div>

--- a/app/templates/dating-summary.hbs
+++ b/app/templates/dating-summary.hbs
@@ -19,14 +19,14 @@
 {{#each m.characters as |c|}}
   <li>
     <div>
-      <LinkTo @route="char" @model={{c.name}}>
+      <LinkTo @route="char" @model={{c.name}} @query={{hash dater=alt.char.name}}>
         {{#if c.icon}}
         <img alt="{{c.name}}'s icon" class="small-profile-icon" src="/game/uploads/{{c.icon}}">
         {{else}}
         <img alt="{{c.name}}'s icon" class="small-profile-icon" src="/game/uploads/theme_images/noicon.png">
         {{/if}}
       </LinkTo>
-      <LinkTo @route="char" @model={{c.name}}>{{c.name}}</LinkTo>
+      <LinkTo @route="char" @model={{c.name}} @query={{hash dater=alt.char.name}}>{{c.name}}</LinkTo>
     </div>
   </li>
 {{/each}}

--- a/app/templates/dating.hbs
+++ b/app/templates/dating.hbs
@@ -34,7 +34,7 @@
         {{else}}
         <img src="/game/uploads/theme_images/noicon.png" class="dating-profile-image" alt="{{this.model.profile.name}}'s icon" >
         {{/if}}
-        <LinkTo @route="char" @model={{this.model.profile.name}} class="dating-profile-link">View Profile</LinkTo>
+        <LinkTo @route="char" @model={{this.model.profile.name}} @query={{hash dater=this.dater}} class="dating-profile-link">View Profile</LinkTo>
       </div>
       <div class="col-lg">
         <div class="dating-facts-box">
@@ -67,14 +67,14 @@
   <div id="matches" class="tab-pane fade show {{unless this.model.profile 'active'}}">
     {{#each this.model.matches as |list|}}
     <h2>{{list.name}}</h2>
-    <CharGroupList @name="" @chars={{list.characters}} />
+    <CharGroupList @name="" @chars={{list.characters}} @dater={{this.dater}} />
     {{/each}}
   </div>
 
   <div id="swipes" class="tab-pane fade show">
     {{#each this.model.swipes as |list|}}
     <h2>{{list.name}}</h2>
-    <CharGroupList @name="" @chars={{list.characters}} />
+    <CharGroupList @name="" @chars={{list.characters}} @dater={{this.dater}} />
     {{/each}}
   </div>
 </div>

--- a/app/templates/dating.hbs
+++ b/app/templates/dating.hbs
@@ -3,7 +3,11 @@
 
 <div class="action-buttons">
   <div class="dating-char-select">
-    <PowerSelect @selected={{this.dating.swiping_with}} @options={{this.dating.dating_alts}} @searchEnabled=true @searchField="name" @onChange={{action "daterChanged"}} as |dater|>
+    <PowerSelect @selected={{this.dating.swiping_with}}
+                 @options={{this.dating.dating_alts}}
+                 @searchEnabled=true
+                 @searchField="name"
+                 @onChange={{action "daterChanged"}} as |dater|>
       <CharIconTiny @char={{dater}} />
     </PowerSelect>
   </div>

--- a/app/templates/dating.hbs
+++ b/app/templates/dating.hbs
@@ -3,7 +3,7 @@
 
 <div class="action-buttons">
   <div class="dating-char-select">
-    <PowerSelect @selected={{this.model.swiping_with}} @options={{this.model.dating_alts}} @searchEnabled=true @searchField="name" @onChange={{action "daterChanged"}} as |dater|>
+    <PowerSelect @selected={{this.dating.swiping_with}} @options={{this.dating.dating_alts}} @searchEnabled=true @searchField="name" @onChange={{action "daterChanged"}} as |dater|>
       <CharIconTiny @char={{dater}} />
     </PowerSelect>
   </div>


### PR DESCRIPTION
Instead of tracking which alt is swiping as an attribute on the character model, use the `dater` query parameter, defaulting to the logged-in character (or the first alt in the list, in the case of admins) if it is unset. Admins with dating alts will be able to swipe from character profile pages, admins without dating alts will not see the swiping controls.