### PR TITLE
only show the dating UI for characters that can swipe

### DIFF
--- a/app/components/profile-custom.js
+++ b/app/components/profile-custom.js
@@ -17,6 +17,10 @@ export default Component.extend(Swiping, {
     return this.get('dating.match') || 'None';
   }),
 
+  showDatingUI: computed('canSwipe', 'char.custom.canSwipe', function() {
+    return this.canSwipe && this.char.custom.canSwipe
+  }),
+
   swipe: computed('dating.swipe', function() {
     let swipe = this.get('dating.swipe');
     if (!swipe) {

--- a/app/templates/components/profile-custom.hbs
+++ b/app/templates/components/profile-custom.hbs
@@ -1,7 +1,7 @@
 {{#if this.char.custom.showDatingProfile}}
 <div id="dateprof-dateprof" class="tab-pane fade">
     {{{ansi-format text=char.custom.dateprof}}}
-    {{#if this.canSwipe}}
+    {{#if this.showDatingUI}}
     <div class="dating-ui">
       <div>
         <div class="dating-char-select">


### PR DESCRIPTION
Most players won't even be able to see unapproved characters. But admins can see them, and can see their dating profile, and if they also have dating alts, can even swipe on them. This should not be. So the dating UI should only show up on the tab if both the viewer and the character can swipe.